### PR TITLE
Fix misleading comment

### DIFF
--- a/starter-templates/automation-migration/contracts/evm/src/AutomationReceiver.sol
+++ b/starter-templates/automation-migration/contracts/evm/src/AutomationReceiver.sol
@@ -86,7 +86,8 @@ contract AutomationReceiver is ReceiverTemplate {
     ///         Causes the forwarder to record the transmission as failed so it can be retried.
     error InsufficientGas(uint256 available, uint256 required);
     /// @notice Thrown when onReport is called without a complete workflow identity configuration.
-    ///         The receiver requires exactly one of the two valid options to be satisfied:
+    ///         The receiver requires at least one of the two valid options to be satisfied
+    ///         (satisfying both is also fine):
     ///         (1) workflowId is set, or (2) both workflowOwner and workflowName are set.
     ///         Without at least one complete option the receiver cannot be bound to a specific
     ///         workflow and would accept reports from any DON-signed payload.


### PR DESCRIPTION
The previous [comment](https://github.com/smartcontractkit/cre-templates/blob/1cec03e105d0ef39ed2579cb52008a35b579c168/starter-templates/automation-migration/contracts/evm/src/AutomationReceiver.sol#L89) stated that exactly one of the two valid options is required, but the contract will also work well if both options are satisfied at the same time.