### PR TITLE
Check target size is allowed is true

### DIFF
--- a/starter-templates/automation-migration/README.md
+++ b/starter-templates/automation-migration/README.md
@@ -80,7 +80,7 @@ cast send "$RECEIVER_ADDRESS" \
 ```
 
 **Parameters:**
-- `target`: The address of your existing upkeep contract. Must be a deployed contract — `setCallAllowed` reverts with `TargetHasNoCode` if the address has no code (EOA, mistyped address, or never-deployed contract).
+- `target`: The address of your existing upkeep contract. When allowing (`allowed = true`) it must be a deployed contract — `setCallAllowed` reverts with `TargetHasNoCode` if the address has no code (EOA, mistyped address, or never-deployed contract). The code check is skipped when revoking (`allowed = false`) so an entry can always be removed, even if the target has since self-destructed.
 - `selector`: The 4-byte function selector (computed from the function signature via `cast sig`).
 - `allowed`: Set to `true` to allow, `false` to revoke.
 

--- a/starter-templates/automation-migration/contracts/evm/src/AutomationReceiver.sol
+++ b/starter-templates/automation-migration/contracts/evm/src/AutomationReceiver.sol
@@ -98,8 +98,11 @@ contract AutomationReceiver is ReceiverTemplate {
     /// @dev Closed by default. Register every (target, selector) the migrated upkeep needs,
     ///      e.g. `performUpkeep(bytes)` for custom-logic/log upkeeps, or your specific
     ///      time-based function. Owner-only.
-    ///      Validates that `target` has deployed code at the time of registration; passing an EOA,
-    ///      a mistyped address, or a never-deployed address reverts with `TargetHasNoCode`.
+    ///      When `allowed` is true, validates that `target` has deployed code at the time of
+    ///      registration; passing an EOA, a mistyped address, or a never-deployed address reverts
+    ///      with `TargetHasNoCode`. The check is skipped when `allowed` is false so that an
+    ///      allowlist entry can always be revoked, even if the target has since self-destructed
+    ///      and its code has become empty.
     /// @param target The contract the receiver is permitted to call.
     /// @param selector The 4-byte function selector permitted on `target`.
     /// @param allowed True to permit, false to revoke.
@@ -107,7 +110,7 @@ contract AutomationReceiver is ReceiverTemplate {
         if (target == address(0)) {
             revert InvalidTargetAddress();
         }
-        if (target.code.length == 0) {
+        if (allowed && target.code.length == 0) {
             revert TargetHasNoCode(target);
         }
         s_callAllowed[target][selector] = allowed;

--- a/starter-templates/automation-migration/contracts/evm/test/AutomationReceiver.t.sol
+++ b/starter-templates/automation-migration/contracts/evm/test/AutomationReceiver.t.sol
@@ -263,6 +263,13 @@ contract AutomationReceiverTest {
         receiver.setCallAllowed(eoa, PERFORM_SELECTOR, true);
     }
 
+    function testSetCallAllowedRevocationSkipsCodeCheck() external {
+        // A codeless target (e.g. a self-destructed contract) must still be revocable.
+        address eoa = address(uint160(99));
+        receiver.setCallAllowed(eoa, PERFORM_SELECTOR, false);
+        _assertFalse(receiver.isCallAllowed(eoa, PERFORM_SELECTOR));
+    }
+
     function testIsCallAllowedReflectsState() external {
         _assertFalse(receiver.isCallAllowed(address(target), PERFORM_SELECTOR));
         receiver.setCallAllowed(address(target), PERFORM_SELECTOR, true);


### PR DESCRIPTION
## Summary

Allow revoking an outbound allowlist entry in `AutomationReceiver.setCallAllowed` even when the target no longer has deployed code (e.g. it has self-destructed). Previously the `TargetHasNoCode` guard ran unconditionally, which could permanently block the owner from removing a stale `(target, selector)` pair once the target's bytecode was gone.

## Changes

- **`contracts/evm/src/AutomationReceiver.sol`**: The `target.code.length == 0` check in `setCallAllowed` now only applies when `allowed == true` (registration). Revocation (`allowed == false`) skips the code check so an entry can always be removed. Updated the NatSpec accordingly.
- **`contracts/evm/test/AutomationReceiver.t.sol`**: Added `testSetCallAllowedRevocationSkipsCodeCheck`, verifying a code-less address can be revoked without reverting.
- **`README.md`**: Clarified that the `TargetHasNoCode` check only applies when allowing, and is intentionally skipped when revoking.

## Rationale

Registering a code-less target is almost always a misconfiguration and should still fail loudly. But once a pair is allowlisted, the owner must always be able to remove it — including after the target self-destructs — so the receiver can never be stuck trusting a `(target, selector)` it can no longer clear.

## Test plan

- [x] `forge test` — all 34 tests pass, including the new revocation test.
- [x] Registering an EOA / code-less target still reverts with `TargetHasNoCode` (`testSetCallAllowedRejectsCodelessTarget`).
- [x] Revoking a code-less target succeeds (`testSetCallAllowedRevocationSkipsCodeCheck`).
- [x] No ABI changes → generated TS bindings unaffected.