### PR TITLE
Introduced vendored imports for AutomationReceiver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ cache/
 node_modules/
 bun.lock
 tmp.js
+
+# Allow vendored Chainlink CRE interfaces in Solidity templates
+!starter-templates/automation-migration/contracts/evm/src/vendor/chainlink-evm/contracts/cre/
+!starter-templates/automation-migration/contracts/evm/src/vendor/chainlink-evm/contracts/cre/**

--- a/starter-templates/automation-migration/contracts/evm/foundry.toml
+++ b/starter-templates/automation-migration/contracts/evm/foundry.toml
@@ -2,4 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-remappings = ["@openzeppelin/contracts/=src/vendor/openzeppelin/"]
+remappings = [
+  "@chainlink/contracts/=src/vendor/chainlink-evm/contracts/",
+  "@openzeppelin/contracts@5.0.2/=src/vendor/openzeppelin/"
+]

--- a/starter-templates/automation-migration/contracts/evm/src/AutomationReceiver.sol
+++ b/starter-templates/automation-migration/contracts/evm/src/AutomationReceiver.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.26;
 
 import "./ReceiverTemplate.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {Pausable} from "@openzeppelin/contracts@5.0.2/utils/Pausable.sol";
 
 /**
  * @title AutomationReceiver

--- a/starter-templates/automation-migration/contracts/evm/src/ReceiverTemplate.sol
+++ b/starter-templates/automation-migration/contracts/evm/src/ReceiverTemplate.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IERC165} from "./IERC165.sol";
-import {IReceiver} from "./IReceiver.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IReceiver} from "@chainlink/contracts/cre/src/v1/interfaces/IReceiver.sol";
+import {IERC165} from "@openzeppelin/contracts@5.0.2/utils/introspection/IERC165.sol";
+import {Ownable} from "@openzeppelin/contracts@5.0.2/access/Ownable.sol";
 
 /// @title ReceiverTemplate - Abstract receiver with optional permission controls
 /// @notice Provides flexible, updatable security checks for receiving workflow reports

--- a/starter-templates/automation-migration/contracts/evm/src/vendor/chainlink-evm/contracts/cre/src/v1/interfaces/IReceiver.sol
+++ b/starter-templates/automation-migration/contracts/evm/src/vendor/chainlink-evm/contracts/cre/src/v1/interfaces/IReceiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IERC165} from "./IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts@5.0.2/utils/introspection/IERC165.sol";
 
 /// @title IReceiver - receives keystone reports
 /// @notice Implementations must support the IReceiver interface through ERC165.
@@ -11,8 +11,5 @@ interface IReceiver is IERC165 {
   /// limit. The receiver is responsible for discarding stale reports.
   /// @param metadata Report's metadata.
   /// @param report Workflow report.
-  function onReport(
-    bytes calldata metadata,
-    bytes calldata report
-  ) external;
+  function onReport(bytes calldata metadata, bytes calldata report) external;
 }

--- a/starter-templates/automation-migration/contracts/evm/src/vendor/openzeppelin/utils/introspection/IERC165.sol
+++ b/starter-templates/automation-migration/contracts/evm/src/vendor/openzeppelin/utils/introspection/IERC165.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.4.0) (utils/introspection/IERC165.sol)
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/introspection/IERC165.sol)
 
-pragma solidity >=0.4.16;
+pragma solidity ^0.8.20;
 
 /**
- * @dev Interface of the ERC-165 standard, as defined in the
- * https://eips.ethereum.org/EIPS/eip-165[ERC].
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
  *
  * Implementers can declare support of contract interfaces, which can then be
  * queried by others ({ERC165Checker}).
@@ -16,12 +16,10 @@ interface IERC165 {
   /**
    * @dev Returns true if this contract implements the interface defined by
    * `interfaceId`. See the corresponding
-   * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]
+   * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
    * to learn more about how these ids are created.
    *
    * This function call must use less than 30 000 gas.
    */
-  function supportsInterface(
-    bytes4 interfaceId
-  ) external view returns (bool);
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }

--- a/starter-templates/automation-migration/contracts/evm/test/AutomationReceiver.t.sol
+++ b/starter-templates/automation-migration/contracts/evm/test/AutomationReceiver.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.19;
 
 import {AutomationReceiver} from "../src/AutomationReceiver.sol";
 import {ReceiverTemplate} from "../src/ReceiverTemplate.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {Ownable} from "@openzeppelin/contracts@5.0.2/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts@5.0.2/utils/Pausable.sol";
 
 interface Vm {
     function prank(address msgSender) external;


### PR DESCRIPTION
After stripping Solidity CBOR metadata, the executable bytecode matches.

AutomationReceiver:

creation bytecode executable:
baseline sha256 = 94c627ee68128347d1c7e6330d48a14cf1d8dad9c39b8e7dcd6931f55378de59
after    sha256 = 94c627ee68128347d1c7e6330d48a14cf1d8dad9c39b8e7dcd6931f55378de59
match = true

deployed runtime executable:
baseline sha256 = f49b10f5ea4bfb8f897c047487abf0e4749f9b3463e93a569d31e837d020a8fe
after    sha256 = f49b10f5ea4bfb8f897c047487abf0e4749f9b3463e93a569d31e837d020a8fe
match = true

So the full artifact bytecode changed only because the metadata trailer changed. The executable code is identical.