### PR TITLE
Update hello-confidential-workflows descriptions

### DIFF
--- a/starter-templates/hello-confidential-workflows/README.md
+++ b/starter-templates/hello-confidential-workflows/README.md
@@ -1,6 +1,6 @@
 # Hello Confidential Workflows
 
-Quickstart confidential workflow. Run a handler's callback inside a secure enclave: fetch a secret from the Vault DON, call an API from inside the enclave, execute decision logic over the confidential data such as Vault DON secrets or HTTP response payloads, then cross back to the Workflow DON for consensus.
+Quickstart confidential workflow. Run a handler's callback inside a secure enclave: fetch a secret from the Vault DON, call an API from inside the enclave, execute decision logic over the confidential data such as Vault DON secrets or HTTP response payloads, then cross back to the Workflow DON for consensus and DON capability calls. 
 
 Note that a confidential workflow, despite running inside the enclave, is part of the binary the Workflow DON provides to the enclave. That binary — including the logic to be executed in the enclave — is revealed; what the enclave keeps confidential is the data that logic computes over.
 

--- a/starter-templates/hello-confidential-workflows/hello-confidential-workflows-go/README.md
+++ b/starter-templates/hello-confidential-workflows/hello-confidential-workflows-go/README.md
@@ -1,6 +1,6 @@
 # Hello Confidential Workflows — CRE Starter Template (Go)
 
-Quickstart confidential workflow. Run a handler's callback inside a secure enclave: fetch a secret from the Vault DON, call an API from inside the enclave, execute decision logic over the confidential data such as Vault DON secrets or HTTP response payloads, then cross back to the Workflow DON for consensus.
+Quickstart confidential workflow. Run a handler's callback inside a secure enclave: fetch a secret from the Vault DON, call an API from inside the enclave, execute decision logic over the confidential data such as Vault DON secrets or HTTP response payloads, then cross back to the Workflow DON for consensus and DON capability calls. 
 
 **⚠️ DISCLAIMER**
 
@@ -29,7 +29,7 @@ A **Confidential Workflow** moves that computation into a hardware-isolated [enc
 
 ### Use Cases
 
-- **Automated liquidation protection**: Automatically protect DeFi lending positions by continuously monitoring liquidation risk and executing collateral management, debt repayment, position reduction, or hedging strategies while preserving the confidentiality of centralized exchange as well as LLM API keys, proprietary risk management thresholds, and execution preferences.
+- **Automated liquidation protection**: Automatically protect DeFi lending positions by continuously monitoring liquidation risk and executing collateral management, debt repayment while preserving the confidentiality of centralized exchange as well as LLM API keys, proprietary risk management thresholds, and execution preferences.
 - **Automated portfolio rebalancing**: Automatically rebalance crypto portfolios by continuously monitoring allocation drift and executing portfolio adjustments when predefined thresholds are exceeded, while preserving the confidentiality of exchange API keys, LLM reasoning, portfolio allocation thresholds, and execution preferences.
 - **AI smart contract audit firewall**: Automatically analyze and screen smart contract interactions before execution to detect and block malicious transactions, while preserving the confidentiality of chain scanner and LLM reasoning API credentials.
 
@@ -197,7 +197,7 @@ Consequences worth internalizing:
 - **`UsingTheDons()` is a one-way door.** Anything you pass into a capability call on that runtime executes on Workflow DON nodes like any non-confidential call. Cross over only the data that does not need to stay confidential.
 - **Logs are for simulation only.** Every `runtime.Logger()` call inside the enclave MUST be removed before deploying to production to preserve the confidentiality offered by enclaves — and logging should be avoided for sensitive and non-sensitive values alike.
 - **Keep enclave logic deterministic.** The Workflow DON verifies enclave attestations and reaches consensus before the workflow completes successfully.
-- **Enclaves are not tenant-isolated today.** A single enclave can run confidential workflows from multiple customers concurrently, sharing execution memory. Isolation between confidential executions is planned, not part of the current beta.
+- **Multiple confidential workflows may execute within the same enclave.** Workflows are isolated from one another by the wasmtime. Dedicated per workflow enclave isolation is planned as a future enhancement.
 
 ## Customization
 

--- a/starter-templates/hello-confidential-workflows/hello-confidential-workflows-ts/README.md
+++ b/starter-templates/hello-confidential-workflows/hello-confidential-workflows-ts/README.md
@@ -1,6 +1,6 @@
 # Hello Confidential Workflows — CRE Starter Template (TypeScript)
 
-Quickstart confidential workflow. Run a handler's callback inside a secure enclave: fetch a secret from the Vault DON, call an API from inside the enclave, execute decision logic over the confidential data such as Vault DON secrets or HTTP response payloads, then cross back to the Workflow DON for consensus.
+Quickstart confidential workflow. Run a handler's callback inside a secure enclave: fetch a secret from the Vault DON, call an API from inside the enclave, execute decision logic over the confidential data such as Vault DON secrets or HTTP response payloads, then cross back to the Workflow DON for consensus and DON capability calls. 
 
 **⚠️ DISCLAIMER**
 
@@ -27,7 +27,7 @@ A **Confidential Workflow** moves that computation into a hardware-isolated [enc
 
 ### Use Cases
 
-- **Automated liquidation protection**: Automatically protect DeFi lending positions by continuously monitoring liquidation risk and executing collateral management, debt repayment, position reduction, or hedging strategies while preserving the confidentiality of centralized exchange as well as LLM API keys, proprietary risk management thresholds, and execution preferences.
+- **Automated liquidation protection**: Automatically protect DeFi lending positions by continuously monitoring liquidation risk and executing collateral management, debt repayment while preserving the confidentiality of centralized exchange as well as LLM API keys, proprietary risk management thresholds, and execution preferences.
 - **Automated portfolio rebalancing**: Automatically rebalance crypto portfolios by continuously monitoring allocation drift and executing portfolio adjustments when predefined thresholds are exceeded, while preserving the confidentiality of exchange API keys, LLM reasoning, portfolio allocation thresholds, and execution preferences.
 - **AI smart contract audit firewall**: Automatically analyze and screen smart contract interactions before execution to detect and block malicious transactions, while preserving the confidentiality of chain scanner and LLM reasoning API credentials.
 
@@ -185,7 +185,7 @@ Consequences worth internalizing:
 - **`usingTheDons()` is a one-way door.** Anything you pass into a capability call on that runtime executes on Workflow DON nodes like any non-confidential call. Cross over only the data that does not need to stay confidential.
 - **Logs are for simulation only.** Every `runtime.log()` inside the enclave MUST be removed before deploying to production to preserve the confidentiality offered by enclaves — and logging should be avoided for sensitive and non-sensitive values alike.
 - **Keep enclave logic deterministic.** The Workflow DON verifies enclave attestations and reaches consensus before the workflow completes successfully.
-- **Enclaves are not tenant-isolated today.** A single enclave can run confidential workflows from multiple customers concurrently, sharing execution memory. Isolation between confidential executions is planned, not part of the current beta.
+- **Multiple confidential workflows may execute within the same enclave.** Workflows are isolated from one another by the wasmtime. Dedicated per workflow enclave isolation is planned as a future enhancement.
 
 ## Customization
 


### PR DESCRIPTION
## Summary
- Clarified the quickstart description to note the workflow crosses back to the Workflow DON for both consensus and DON capability calls.
- Trimmed the "Automated liquidation protection" use case bullet, removing "position reduction, or hedging strategies" from the example.
- Reworded the enclave isolation caveat: replaced "Enclaves are not tenant-isolated today" language with a more accurate description — workflows within the same enclave are isolated from one another via wasmtime, with dedicated per-workflow enclave isolation planned as a future enhancement.

Applied consistently across the root README and both the Go and TS template READMEs.